### PR TITLE
(bug) Align git version across platforms

### DIFF
--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -3,6 +3,11 @@ local := false
 openmp := true
 flags += -Wno-narrowing -Wno-multichar -g -fPIC
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	flags += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(platform), ios-arm64)
 	flags += -fPIC -miphoneos-version-min=11.0 -Wno-error=implicit-function-declaration -DHAVE_POSIX_MEMALIGN
 	options += -dynamiclib


### PR DESCRIPTION
This commit makes `bsnes/target-libretro/GNUmakefile` derive the short `HEAD` hash with `git rev-parse --short HEAD` and pass it through `-DGIT_VERSION` when the value is available.

Before this, GNU make builds (macOS) could omit the same git version metadata used elsewhere, which left platform builds reporting different version strings. This change aligns the versioning caught on Linux with other platforms.

Same changes as https://github.com/epilogue-co/libretro-bsnes/blob/187b52e1aab7a978bd2190261880af9bbba7c50e/Makefile#L59-L63